### PR TITLE
Feature/GitHub api call throttling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1533,6 +1533,11 @@
       "dev": true,
       "optional": true
     },
+    "bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "gatsby": "^2.6.0"
   },
   "dependencies": {
+    "bottleneck": "^2.19.5",
     "chalk": "^2.4.2",
     "crypto": "^1.0.1",
     "git-url-parse": "^11.1.2",

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -25,6 +25,7 @@ import fetch from 'node-fetch';
  * @param {String} token
  */
 export const fetchFile = async (path, token) => {
+  console.log(`Retrieving resource from "${path}"`);
   const result = await fetch(path, {
     method: 'GET',
     headers: {


### PR DESCRIPTION
## Summary
We have been getting rate/abuse limited by Github lately due to the number of parallel api calls we are making.  This PR introduces rate limiting / throttling using `bottleneck` to prevent this from happening.

## Notable Changes <!-- if any -->
- added `bottleneck` dependency
- create `bottleneck` proxy/wrapper with a reasonable/recommended config to control number of calls
- wrapping call to `fetch` 
-
-
-
