### PR TITLE
Fixes package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A simplified way of leveraging the `Github Contents Api` as Gatsby graphql nodes
 - Add to your gatsby config
 ```js
 {
-  resolve: 'gatsby-source-github-raw',
+  resolve: '@bcgov/gatsby-source-github-raw',
   options: {
     githubAccessToken: '...',
     files: [
@@ -83,7 +83,7 @@ The implied `nodeType` that is created from the directory can be passed in as th
 > gatbsy-config
 ```js
 {
-  resolve: 'gatsby-source-github-raw',
+  resolve: '@bcgov/gatsby-source-github-raw',
   options: {
     githubAccessToken: '...',
     files: 'fooJson'
@@ -107,7 +107,7 @@ const fileCallback = getNodes => {
 
 ```js
 {
-  resolve: 'gatsby-source-github-raw',
+  resolve: '@bcgov/gatsby-source-github-raw',
   options: {
     githubAccessToken: '...',
     files: () => ['https://github.com/foo/bar/blob/master/blah.md']
@@ -118,7 +118,7 @@ const fileCallback = getNodes => {
 ## Exceptions to applying bound properties
 
 Because manifests can be passed in as plain js objects as well as loaded through the use of 
-`gatsby-transformer-json`, to maintain consistency between these two possible sources, the following
+`@bcgov/gatsby-transformer-json`, to maintain consistency between these two possible sources, the following
 properties are not usable within `json` files that are leveraged as a source for files.
 
 - internal


### PR DESCRIPTION
## Summary

This PR corrects the package name to `@bcgov/gatsby-source-github-raw` in the `README.md` file, so the Gatsby config will work. Thanks!